### PR TITLE
Fix location of pixi.js dependency

### DIFF
--- a/webpack.config.js
+++ b/webpack.config.js
@@ -2,7 +2,7 @@ var path = require('path')
 var webpack = require('webpack')
 
 var projectRoot = path.resolve(__dirname, '../')
-var pixiModule = path.join(__dirname, '/node_modules/pixi.js/bin/pixi.js')
+var pixiModule = path.join(__dirname, '/node_modules/pixi.js/')
 
 let config = {
     entry: path.resolve(__dirname, 'src/main.js'),


### PR DESCRIPTION
I was getting a compilation error with the current location. I did try to target the pre-built dist but webpack through a warning:
var pixiModule = path.join(__dirname, '/node_modules/pixi.js/dist/pixi.js')